### PR TITLE
Set Default Image Size to Thumbnail

### DIFF
--- a/classes/class-post-link-manager.php
+++ b/classes/class-post-link-manager.php
@@ -330,7 +330,7 @@ class RP4WP_Post_Link_Manager {
 						 *
 						 * @api String $thumbnail_size The current/default thumbnail size.
 						 */
-						$thumb_size = apply_filters( 'rp4wp_thumbnail_size', 'post-thumbnail' );
+						$thumb_size = apply_filters( 'rp4wp_thumbnail_size', 'thumbnail' );
 
 						$content .= "<div class='rp4wp-related-post-image'>" . PHP_EOL;
 						$content .= "<a href='" . get_permalink( $rp4wp_post->ID ) . "'>";


### PR DESCRIPTION
I noticed that right now you're using a default of post-thumbnail which isn't set anywhere. As it stands, the full size image is displayed. Did you mean to use the default WordPress thumbnail size? If not, please disregard. :)
