### PR TITLE
static hook loading (instead of directory scan)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /node_modules/
-composer.lock
 
 # Exclude everything in /vendor except our autoload stuff
 vendor/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,9 @@
 /node_modules/
+composer.lock
+
+# Exclude everything in /vendor except our autoload stuff
+vendor/*
+!vendor/composer
+!vendor/autoload_52.php
+vendor/composer/installers
+vendor/composer/installed.json

--- a/classes/class-manager-filter.php
+++ b/classes/class-manager-filter.php
@@ -8,45 +8,37 @@ if ( ! class_exists( 'RP4WP_Manager_Filter' ) ) {
 
 	class RP4WP_Manager_Filter {
 
-		private $filter_dir;
+		private $filter_names;
 		private static $filters;
 
-		public function __construct( $filter_dir ) {
-			$this->filter_dir = $filter_dir;
+		/**
+		 * @param array $filter_names
+		 */
+		public function __construct( array $filter_names ) {
+			$this->filter_names = $filter_names;
 		}
 
 		/**
 		 * Load on specific filter instead of all filters.
 		 * This method should be used when the load_filters() isn't run yet, for example in the (de)activation process.
 		 *
-		 * @param $file_name
+		 * @param string $filter_name
 		 */
-		public function load_filter( $file_name ) {
-			$class = RP4WP_Class_Manager::format_class_name( $file_name );
-			if ( 'RP4WP_Filter' != $class ) {
-				self::$filters[$class] = new $class;
-			}
+		public function load_filter( $filter_name ) {
+			$class_name = "RP4WP_Filter_" . str_replace( ' ', '_', ucwords( str_replace( '_', ' ', $filter_name ) ) );
+			self::$filters[$class_name] = new $class_name;
 		}
 
 		/**
 		 * Load and set hooks
 		 *
 		 * @access public
-		 * @static
 		 * @return void
 		 */
 		public function load_filters() {
 
-			foreach ( new DirectoryIterator( $this->filter_dir ) as $file ) {
-
-				if ( ! $file->isDir() && ( strpos( $file->getFileName(), '.' ) !== 0 ) ) {
-
-					$class = RP4WP_Class_Manager::format_class_name( $file->getFileName() );
-					if ( 'RP4WP_Filter' != $class ) {
-						self::$filters[$class] = new $class;
-					}
-
-				}
+			foreach( $this->filter_names as $filter_name ) {
+				$this->load_filter( $filter_name );
 			}
 
 		}

--- a/classes/class-manager-hook.php
+++ b/classes/class-manager-hook.php
@@ -8,33 +8,34 @@ if ( ! class_exists( 'RP4WP_Manager_Hook' ) ) {
 
 	class RP4WP_Manager_Hook {
 
-		private $hook_dir;
+		private $action_names = array();
 		private static $hooks;
 
-		public function __construct( $hook_dir ) {
-			$this->hook_dir = $hook_dir;
+		/**
+		 * @param array $action_names
+		 */
+		public function __construct( array $action_names ) {
+			$this->action_names = $action_names;
+		}
+
+		/**
+		 * @param string $action_name
+		 */
+		public function load_hook( $action_name ) {
+			$class_name = "RP4WP_Hook_" . str_replace( ' ', '_', ucwords( str_replace( '_', ' ', $action_name ) ) );
+			self::$hooks[$class_name] = new $class_name;
 		}
 
 		/**
 		 * Load and set hooks
 		 *
 		 * @access public
-		 * @static
 		 * @return void
 		 */
 		public function load_hooks() {
 
-			foreach ( new DirectoryIterator( $this->hook_dir ) as $file ) {
-
-				if ( ! $file->isDir() && ( strpos( $file->getFileName(), '.' ) !== 0 ) ) {
-
-					$class = RP4WP_Class_Manager::format_class_name( $file->getFileName() );
-					if ( 'RP4WP_Hook' != $class ) {
-						self::$hooks[$class] = new $class;
-					}
-
-				}
-
+			foreach( $this->action_names as $action_name ) {
+				$this->load_hook( $action_name );
 			}
 
 		}

--- a/classes/class-rp4wp.php
+++ b/classes/class-rp4wp.php
@@ -97,11 +97,13 @@ class RP4WP {
 		add_action( 'init', array( $this, 'setup_settings' ) );
 
 		// Filters
-		$manager_filter = new RP4WP_Manager_Filter( plugin_dir_path( RP4WP_PLUGIN_FILE ) . 'classes/filters/' );
+		$filters = include dirname( RP4WP_PLUGIN_FILE ) .'/includes/filters.php';
+		$manager_filter = new RP4WP_Manager_Filter( $filters );
 		$manager_filter->load_filters();
 
 		// Hooks
-		$manager_hook = new RP4WP_Manager_Hook( plugin_dir_path( RP4WP_PLUGIN_FILE ) . 'classes/hooks/' );
+		$actions = include dirname( RP4WP_PLUGIN_FILE ) .'/includes/actions.php';
+		$manager_hook = new RP4WP_Manager_Hook( $actions );
 		$manager_hook->load_hooks();
 
 		// Include template functions

--- a/includes/actions.php
+++ b/includes/actions.php
@@ -1,0 +1,20 @@
+<?php
+
+return array(
+	'admin_scripts',
+	'ajax_delete_link',
+	'ajax_install_link_posts',
+	'ajax_install_save_words',
+	'delete_words',
+	'frontend_css',
+	'link_related_screen',
+	'meta_box',
+	'meta_box_ajax_sort',
+	'page_install',
+	'post_type',
+	'related_auto_link',
+	'related_save_words',
+	'settings_page',
+	'shortcode',
+	'widget'
+);

--- a/includes/filters.php
+++ b/includes/filters.php
@@ -1,0 +1,6 @@
+<?php
+
+return array(
+	'after_post',
+	'plugin_links'
+);


### PR DESCRIPTION
See #64

> Instead of performing a directory scan, filters & action hooks are loaded from two configuration files. This might be not as DRY but it's less resource intensive. A better option might be to perform some sort of static scan that dumps an optimised filter file (much like Composer's optimised autoloader)