### PR TITLE
Additional shortcode attribute for adding custom CSS class(es)

### DIFF
--- a/classes/class-post-link-manager.php
+++ b/classes/class-post-link-manager.php
@@ -366,13 +366,14 @@ class RP4WP_Post_Link_Manager {
 	 *
 	 * @param int $id
 	 * @param int $limit
+	 * @param str $class
 	 *
-	 * @since  1.0.0
+	 * @since  2.0.1
 	 * @access public
 	 *
 	 * @return string
 	 */
-	public function generate_children_list( $id, $limit = -1 ) {
+	public function generate_children_list( $id, $limit = -1, $class = '' ) {
 
 		// The content
 		$content = '';
@@ -383,8 +384,8 @@ class RP4WP_Post_Link_Manager {
 		// Count
 		if ( count( $related_posts ) > 0 ) {
 
-			// The rp4wp block
-			$content .= "<div class='rp4wp-related-posts'>\n";
+			// The rp4wp block with additional css class (if any)
+			$content .= "<div class='rp4wp-related-posts ".$class."'>\n";
 
 			// Get the heading text
 			$heading_text = RP4WP::get()->settings->get_option( 'heading_text' );

--- a/classes/class-post-link-manager.php
+++ b/classes/class-post-link-manager.php
@@ -368,7 +368,7 @@ class RP4WP_Post_Link_Manager {
 	 * @param int $limit
 	 * @param str $class
 	 *
-	 * @since  2.0.1
+	 * @since  1.0.0
 	 * @access public
 	 *
 	 * @return string

--- a/classes/hooks/class-hook-shortcode.php
+++ b/classes/hooks/class-hook-shortcode.php
@@ -22,13 +22,14 @@ class RP4WP_Hook_Shortcode extends RP4WP_Hook {
 
 		$atts = shortcode_atts( array(
 			'id'    => get_the_ID(),
-			'limit' => -1
+			'limit' => -1,
+			'class' => ''
 		), $atts );
 
 		// Post Link Manager
 		$pl_manager = new RP4WP_Post_Link_Manager();
 
 		// Generate the children list
-		return $pl_manager->generate_children_list( $atts['id'], $atts['limit'] );
+		return $pl_manager->generate_children_list( $atts['id'], $atts['limit'], $atts['class'] );
 	}
 }


### PR DESCRIPTION
A quick alteration that simply adds an extra argument 'class' to the shortcode and link manager's generated output. I'm not familiar enough with the codebase to know if it needs additional setup etc. but on testing it works a charm.

Now I can have my own custom classes and use several different styles to display relevant posts in a more customizable way. For example:
```
...post content...
[rp4wp class="style-1"]
...post content...
[rp4wp class="style-2 aligncenter bold dark-background"]
...post content...
```
This is something I'll be using myself, so I just thought I'd give a pull request to see if it can be added to the next version.