### PR TITLE
Fix PHP deprecation warnings in PHP 8.1

### DIFF
--- a/classes/hooks/class-hook-link-related-screen.php
+++ b/classes/hooks/class-hook-link-related-screen.php
@@ -19,7 +19,7 @@ class RP4WP_Hook_Link_Related_Screen extends RP4WP_Hook {
 		$this->catch_search();
 
 		// Add Page
-		$screen_hook = add_submenu_page( null, 'Link_Related_Screen', 'Link_Related_Screen', 'edit_posts', 'rp4wp_link_related', array( $this, 'content' ) );
+		$screen_hook = add_submenu_page( '', 'Link_Related_Screen', 'Link_Related_Screen', 'edit_posts', 'rp4wp_link_related', array( $this, 'content' ) );
 
 		// add screen options
 		add_action( 'load-' . $screen_hook, array( $this, 'init_screen' ) );

--- a/classes/hooks/class-hook-page-install.php
+++ b/classes/hooks/class-hook-page-install.php
@@ -9,7 +9,7 @@ class RP4WP_Hook_Page_Install extends RP4WP_Hook {
 
 	public function run() {
 
-		$menu_hook = add_submenu_page( null, 'RP4WPINSTALL', 'RP4WPINSTALL', 'edit_posts', 'rp4wp_install', array(
+		$menu_hook = add_submenu_page( '', 'RP4WPINSTALL', 'RP4WPINSTALL', 'edit_posts', 'rp4wp_install', array(
 				$this,
 				'content'
 			) );


### PR DESCRIPTION
Passing `null` to `add_submenu_page()` as the first argument is causing various PHP deprecation warnings because WordPress expects the parent argument to be a string.

<img width="1721" alt="" src="https://github.com/barrykooij/related-posts-for-wp/assets/617637/3b5eb073-f29e-44d4-a6dc-4e6e05201290">

The fix would be to just use an empty string instead.

In the premium version you should also set `$parent = ''` in `RP4WP_Hook_Settings_Page:run()`. Thanks!